### PR TITLE
Fixed typographical error, changed auxilary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features
 - Command completion (with commands defined in the source, \ref your \label, \cite your bibitem and bibfile)
 - Integrated pdf viewer (auto sync during scrolling, reverse sync with Ctrl+Click on the pdf)
 - Spell checker
-- Hide auxilary files
+- Hide auxiliary files
 - Search with regex
 - Splitable editor
 - Quickly open associted files (input, bibliography)


### PR DESCRIPTION
Bramas, I've corrected a typographical error in the documentation of the [texiteasy](https://github.com/Bramas/texiteasy) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.