### PR TITLE
Fix words being split at special characters missing from list

### DIFF
--- a/source/syntaxhighlighter.cpp
+++ b/source/syntaxhighlighter.cpp
@@ -1021,6 +1021,6 @@ void SyntaxHighlighter::highlightExpression(const QString &text, const QString &
 
 bool SyntaxHighlighter::isWordSeparator(QChar c) const
 {
-    return QString(c).contains(QRegExp(QString::fromUtf8("[^a-zâãäåàæçèéêëìíîïðñòóôõøùúûüýþÿıœ]"),Qt::CaseInsensitive));
+    return QString(c).contains(QRegExp(QString::fromUtf8("[^\\w]"),Qt::CaseInsensitive));
 }
 


### PR DESCRIPTION
Some special characters (ö, ß) were missing from the regex of word characters. After adding them the regex would probably still be incomplete, so I used \w instead as a more general solution.
![image](https://cloud.githubusercontent.com/assets/10547985/11638519/b6584c58-9d27-11e5-9336-cb58fabbad26.png)
